### PR TITLE
Fixed PermissionsBitField name

### DIFF
--- a/Command.js
+++ b/Command.js
@@ -68,12 +68,12 @@ class Command {
     }
 
     static addMemberToPrivateChannel(member, channel){
-        const newPermision = { VIEW_CHANNEL: true };
+        const newPermision = { ViewChannel: true };
         channel.permissionOverwrites.edit(member, newPermision);
     }
 
     static removeMemberFromPrivateChannel(member, channel){
-        const newPermision = { VIEW_CHANNEL: false };
+        const newPermision = { ViewChannel: false };
         channel.permissionOverwrites.edit(member, newPermision);
     }
 


### PR DESCRIPTION
PermissionsBitField flag names changed from discord.js v13 to discord.js v14. This was missed when updating dependencies.

Fixes #50 